### PR TITLE
Fixed PEP8 warnings and newlines issue 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+**/.idea/

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ Can also supports environment files in json
 
 ```sh
 $ cat env.json
+```
+```json
 {
-CANARD": "true",
-LAPIN": "12343",
-BONJOUR_LES_GENS": "abcdef"
+  "CANARD": "true",
+  "LAPIN": "12343",
+  "BONJOUR_LES_GENS": "abcdef"
 }
 ```
 
@@ -68,5 +70,4 @@ data:
   canard: dHJ1ZQ==
   lapin: MTIzNDM=
   bonjour_les_gens: YWJjZGVm
-  secret_file: aGVsbG8K
 ```

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 import base64
 import json
 from string import Template
+import re
 
 parser = argparse.ArgumentParser(description='Convert environment files to kubernetes secrets')
 parser.add_argument('--name', metavar='name', nargs='?', type=str, default='my-secrets',
@@ -11,6 +12,8 @@ parser.add_argument('--env', metavar='.env', nargs='?', type=argparse.FileType('
                     help='Environment input file, stdin by default')
 parser.add_argument('--secrets', metavar='.yaml', nargs='?', type=argparse.FileType('w'), default=sys.stdout,
                     help='Secrets output file, stdout by default')
+
+env_regex = re.compile(r'^(?P<variable>[a-zA-Z]\w*)\s*=\s*(?P<value>.*?)\s*?(?P<comment>#.*?)?$')
 
 
 def load_files(secret):
@@ -39,11 +42,13 @@ $encodedSecrets""")
 
 
 def process_plainfile(_args):
-    config_lines = _args.env.readlines()
+    config_lines = _args.env.read().splitlines()
     _args.env.close()
-    secrets = [line.split('=', 1) for line in config_lines]
-    secrets = map(load_files, secrets)
-
+    secrets = []
+    for line in config_lines:
+        m = env_regex.match(line)
+        if m:
+            secrets.append((m.group('variable'), m.group('value')))
     encoded_secrets = ['  {0}: {1}'.format(
         secret[0],
         base64.b64encode(secret[1].replace('\n', '').encode('utf-8')).decode('utf-8')

--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ def process_plainfile(_args):
         m = env_regex.match(line)
         if m:
             secrets.append((m.group('variable'), m.group('value')))
+    secrets = map(load_files, secrets)
     encoded_secrets = ['  {0}: {1}'.format(
         secret[0],
         base64.b64encode(secret[1].replace('\n', '').encode('utf-8')).decode('utf-8')

--- a/main.py
+++ b/main.py
@@ -5,22 +5,26 @@ import json
 from string import Template
 
 parser = argparse.ArgumentParser(description='Convert environment files to kubernetes secrets')
-parser.add_argument('--name', metavar='name', nargs='?', type=str, default='my-secrets', help='Name of the secret store')
-parser.add_argument('--env', metavar='.env', nargs='?', type=argparse.FileType('r'), default=sys.stdin, help='Environment input file, stdin by default')
-parser.add_argument('--secrets', metavar='.yaml', nargs='?', type=argparse.FileType('w'), default=sys.stdout, help='Secrets output file, stdout by default')
+parser.add_argument('--name', metavar='name', nargs='?', type=str, default='my-secrets',
+                    help='Name of the secret store')
+parser.add_argument('--env', metavar='.env', nargs='?', type=argparse.FileType('r'), default=sys.stdin,
+                    help='Environment input file, stdin by default')
+parser.add_argument('--secrets', metavar='.yaml', nargs='?', type=argparse.FileType('w'), default=sys.stdout,
+                    help='Secrets output file, stdout by default')
 
 
-def loadFiles(secret):
-    if (secret[1].startswith('filecontent=')):
+def load_files(secret):
+    if secret[1].startswith('filecontent='):
         with open(secret[1][12:], 'r') as secretfile:
             data = secretfile.read()
         return [secret[0], data]
     return secret
 
-def yaml_ouput(encodedSecrets):
-    '''secrets its a tuple with key, value format'''
 
-    yamlTemplate = Template("""
+def yaml_ouput(encoded_secrets):
+    """secrets its a tuple with key, value format"""
+
+    yaml_template = Template("""
 apiVersion: v1
 kind: Secret
 metadata:
@@ -28,35 +32,38 @@ metadata:
 type: Opaque
 data:
 $encodedSecrets""")
-    yamlOutput = yamlTemplate.substitute(name=args.name, encodedSecrets='\n'.join(encodedSecrets))
+    yaml_output = yaml_template.substitute(name=args.name, encodedSecrets='\n'.join(encoded_secrets))
 
-    args.secrets.write(yamlOutput)
+    args.secrets.write(yaml_output)
     args.secrets.close()
 
-def process_plainfile(args):
-    config_lines = args.env.readlines()
-    args.env.close()
-    secrets = [line.split('=', 1) for line in config_lines]
-    secrets = map(loadFiles, secrets)
 
-    encodedSecrets = ['  {0}: {1}'.format(
+def process_plainfile(_args):
+    config_lines = _args.env.readlines()
+    _args.env.close()
+    secrets = [line.split('=', 1) for line in config_lines]
+    secrets = map(load_files, secrets)
+
+    encoded_secrets = ['  {0}: {1}'.format(
         secret[0],
         base64.b64encode(secret[1].replace('\n', '').encode('utf-8')).decode('utf-8')
     ) for secret in secrets]
 
-    yaml_ouput(encodedSecrets)
+    yaml_ouput(encoded_secrets)
 
-def process_json(args):
-    json_dict = json.loads(args.env.read())
-    args.env.close()
+
+def process_json(_args):
+    json_dict = json.loads(_args.env.read())
+    _args.env.close()
     secrets = list(json_dict.items())
-    encodedSecrets = [
+    encoded_secrets = [
         '  {0}: {1}'.format(
-                secret[0],
-                base64.b64encode(str(secret[1]).encode('utf-8')).decode('utf-8')
+            secret[0],
+            base64.b64encode(str(secret[1]).encode('utf-8')).decode('utf-8')
         )
-    for secret in secrets]
-    yaml_ouput(encodedSecrets)
+        for secret in secrets]
+    yaml_ouput(encoded_secrets)
+
 
 if __name__ == '__main__':
     args = parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ parser.add_argument('--env', metavar='.env', nargs='?', type=argparse.FileType('
 parser.add_argument('--secrets', metavar='.yaml', nargs='?', type=argparse.FileType('w'), default=sys.stdout,
                     help='Secrets output file, stdout by default')
 
-env_regex = re.compile(r'^(?P<variable>[a-zA-Z]\w*)\s*=\s*(?P<value>.*?)\s*?(?P<comment>#.*?)?$')
+env_regex = re.compile(r'^(?P<variable>[a-zA-Z]\w*)\s*=\s*(?P<value>.*?)(?P<comment>\s+#.*?)?$')
 
 
 def load_files(secret):


### PR DESCRIPTION
Refactor of main.py file with PEP8 style. Renemed params to fix names from outer scope warning. 
.env files now support new lines and comments. In fact, only the variables that match the **env_regex** regular expression will be taken as valid, the rest will be ignored.